### PR TITLE
Remove systemctl dependency from StashCache stats script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,15 +15,13 @@ VERSION := 0.9
 
 SBIN_FILES := src/stashcache
 INSTALL_SBIN_DIR := usr/sbin
-CONDOR_CONFIG := configs/01-stashcache.conf
 XROOTD_CONFIG := configs/Authfile-auth configs/Authfile-noauth configs/stashcache-robots.txt configs/xrootd-stashcache-cache-server.cfg configs/xrootd-stashcache-origin-server.cfg
-SYSTEMD_UNITS := configs/xrootd-renew-proxy.service configs/xrootd-renew-proxy.timer
-INSTALL_CONDOR_DIR := etc/condor/config.d
+SYSTEMD_UNITS := configs/xrootd-renew-proxy.service configs/xrootd-renew-proxy.timer configs/stashcache.service configs/stashcache.timer
 INSTALL_XROOTD_DIR := etc/xrootd
 INSTALL_SYSTEMD_UNITDIR := usr/lib/systemd/system
 PYTHON_LIB := src/xrootd_cache_stats.py
 
-DIST_FILES := $(SBIN_FILES) $(CONDOR_CONFIG) $(PYTHON_LIB) Makefile
+DIST_FILES := $(SBIN_FILES) $(PYTHON_LIB) Makefile
 
 
 # ------------------------------------------------------------------------------
@@ -60,8 +58,6 @@ install:
 	mkdir -p $(DESTDIR)/$(INSTALL_SBIN_DIR)
 	install -p -m 0755 $(SBIN_FILES) $(DESTDIR)/$(INSTALL_SBIN_DIR)
 	sed -i -e 's/##VERSION##/$(VERSION)/g' $(DESTDIR)/$(INSTALL_SBIN_DIR)/stashcache
-	mkdir -p $(DESTDIR)/$(INSTALL_CONDOR_DIR)
-	install -p -m 0644 $(CONDOR_CONFIG) $(DESTDIR)/$(INSTALL_CONDOR_DIR)
 	mkdir -p $(DESTDIR)/$(INSTALL_PYTHON_DIR)
 	install -p -m 0644 $(PYTHON_LIB) $(DESTDIR)/$(INSTALL_PYTHON_DIR)
 	mkdir -p $(DESTDIR)/$(INSTALL_XROOTD_DIR)

--- a/configs/01-stashcache.conf
+++ b/configs/01-stashcache.conf
@@ -1,4 +1,0 @@
-STASHCACHE=/usr/sbin/stashcache
-DAEMON_LIST=MASTER, COLLECTOR, STASHCACHE
-TOOL_LOG=/var/log/condor/StashcacheLog
-TOOL_DEBUG=D_ALWAYS D_ERROR

--- a/configs/stashcache.service
+++ b/configs/stashcache.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Report StashCache usage stats
+
+[Service]
+User=root
+Group=root
+Type=oneshot
+ExecStart=/usr/sbin/stashcache --one-shot
+
+[Install]
+WantedBy=multi-user.target

--- a/configs/stashcache.timer
+++ b/configs/stashcache.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Report StashCache usage stats every 15 minutes
+
+[Timer]
+OnUnitInactiveSec=15m
+Unit=stashcache.service
+
+[Install]
+WantedBy=multi-user.target

--- a/rpm/StashCache-Daemon.spec
+++ b/rpm/StashCache-Daemon.spec
@@ -28,6 +28,13 @@ Requires: fetch-crl
 %description daemon
 %{summary}
 
+%post daemon
+%systemd_post stashcache.service stashcache.timer
+%preun daemon
+%systemd_preun stashcache.service stashcache.timer
+%postun daemon
+%systemd_postun_with_restart stashcache.service stashcache.timer
+
 ########################################
 %package origin-server
 Group: Grid
@@ -96,8 +103,9 @@ mkdir -p %{buildroot}%{_sysconfdir}/grid-security/xrd
 
 %files daemon
 %{_sbindir}/stashcache
-%{_sysconfdir}/condor/config.d/01-stashcache.conf
 %{python_sitelib}/xrootd_cache_stats.py*
+%{_unitdir}/stashcache.service
+%{_unitdir}/stashcache.timer
 
 %files origin-server
 %config(noreplace) %{_sysconfdir}/xrootd/xrootd-stashcache-origin-server.cfg

--- a/src/stashcache
+++ b/src/stashcache
@@ -1,198 +1,85 @@
 #!/bin/env python
 '''
-Shim script to manage XRootD server under condor_master
+Collect XRootD stats and report to HTCondor collector
 '''
 
+# Viewing stats in collector:
+# condor_status -pool collector1.opensciencegrid.org:9619 -any xrootd@hcc-stash.unl.edu -l
+
+import argparse
+import logging
 import os
-import re
 import sys
-import errno
 import socket
-import signal
-import Queue
-import threading
 import time
-import traceback
 
 import htcondor
 import xrootd_cache_stats
 
-from subprocess import Popen, PIPE
-
-_exception_queue = Queue.Queue(0)
-_accepted_signals = {signal.SIGHUP:'restart',
-                     signal.SIGQUIT:'stop',
-                     signal.SIGTERM:'stop'}
-
-class CondorException(Exception):
-    pass
-
-class XrootdException(Exception):
-    pass
-
-class HeartBeatThread(threading.Thread):
-    '''Thread to send heartbeats and cache ads to the master'''
-    def __init__(self, url, exception_queue):
-        self.url = url
-        self.exceptions = exception_queue
-        threading.Thread.__init__(self)
-        self.setDaemon(True)
-
-    def run(self):
-        try:
-            local_coll = htcondor.Collector(self.url)
-            try:
-                central_coll_url = htcondor.param['OSG_COLLECTOR_HOST']
-            except KeyError:
-                central_coll_url = 'collector1.opensciencegrid.org:9619,collector2.opensciencegrid.org:9619'
-            htcondor.log(htcondor.LogLevel.FullDebug, 'Using %s as the central collector' % central_coll_url)
-            central_coll = htcondor.Collector(central_coll_url)
-
-            xrootd_addr = 'root://' + self.url
-            while True:
-                local_master = None
-                while not local_master:
-                    try:
-                        local_master = local_coll.locate(htcondor.DaemonTypes.Master)
-                    except ValueError: # Master has not advertised to the collector yet
-                        pass
-                    except IOError: # Failed communication with collector
-                        raise CondorException('Could not locate Collector at %s' % self.url)
-
-                local_master['STASHCACHE_DaemonVersion'] = ##VERSION##
-                cache_ad = xrootd_cache_stats.collect_cache_stats(xrootd_addr, '/stash')
-                if cache_ad['ping_response_status'] == 'ok':
-                    htcondor.log(htcondor.LogLevel.FullDebug, 'XRootD server (%s) status: OK' % xrootd_addr)
-                    try:
-                        htcondor.send_alive(local_master)
-                    except RuntimeError:
-                        raise CondorException('Failed to deliver keepalive message to condor_master at %s'
-                                              % self.url)
-                    # ads need to be updated every 15 min while heartbeats should be done every 30 min
-                    for _ in range(2):
-                        for collector in local_coll, central_coll:
-                            pool = collector.query(htcondor.AdTypes.Collector)[0]['Machine']
-                            htcondor.log(htcondor.LogLevel.Always, 'Advertising StashCache ads to %s' % pool)
-                            for args in [([local_master], 'UPDATE_MASTER_AD'), ([cache_ad], 'UPDATE_STARTD_AD')]:
-                                collector.advertise(*args)
-                        time.sleep(900)
-                else:
-                    raise XrootdException('No heartbeat from XRootD server')
-        except Exception:
-            # Exceptions don't rise to the main thread so we have to pass them via queue and SIGALARM
-            error = sys.exc_info()
-            self.exceptions.put(error)
-            signal.alarm(1)
-            sys.exit(1)
-
-def raise_heartbeat_exception(signum, frame):
-    '''Raise exception from heartbeat thread'''
-    exc_type, exc_value, exc_tb = _exception_queue.get()
-    kill_xrootd()
-    if exc_type in [XrootdException, CondorException, RuntimeError]:
-        htcondor.log(htcondor.LogLevel.Error, 'ERROR: ' + str(exc_value))
-    else:
-        exc_str = traceback.format_exception(exc_type, exc_value, exc_tb)
-        htcondor.log(htcondor.LogLevel.Error, ''.join(exc_str))
-    htcondor.log(htcondor.LogLevel.Always, 'Stopping StashCache daemon')
-    sys.exit(1)
-
-def manage_xrootd(signum, frame):
-    '''Signal handler for the XRootD service'''
-    command = _accepted_signals[signum]
-    htcondor.log(htcondor.LogLevel.Always,
-                 "Received signal %s: Running '%s' on the XRootD server " % (signum, command))
-
-    rc, _, _ = xrootd_service_command(command)
-    if rc != 0:
-        kill_xrootd()
-        # Restart service if user requested it
-        if signum == signal.SIGHUP:
-            start_xrootd()
-    if signum == signal.SIGQUIT or signum == signal.SIGTERM:
-        sys.exit(0)
-
-def start_xrootd():
-    '''Starts the XRootD init service'''
-    rc, stdout, _ = xrootd_service_command('start')
-    if rc != 0:
-        htcondor.log(htcondor.LogLevel.Error, 'ERROR: Could not start XRootD service: %s' % stdout)
-    else:
-        try:
-            pid = get_xrootd_pid()
-        except AttributeError:
-            pid = 'unknown'
-        htcondor.log(htcondor.LogLevel.Always, 'XRootD service running (PID: %s)' % pid)
-
-def kill_xrootd():
-    '''Sends SIGKILL to an unresponsive XRootD service'''
+def heart_beat(hostname, cache_path='/stash', one_shot=False):
+    '''Send heartbeats and cache ads to the condor_master'''
     try:
-        pid = get_xrootd_pid()
-        os.kill(int(pid), signal.SIGKILL)
-    except (AttributeError, OSError):
-        pass # xrootd already dead
+        central_coll_url = htcondor.param['OSG_COLLECTOR_HOST']
+    except KeyError:
+        central_coll_url = 'collector1.opensciencegrid.org:9619,collector2.opensciencegrid.org:9619'
+    logging.debug('Using %s as the central collector', central_coll_url)
+    central_coll = htcondor.Collector(central_coll_url)
 
-def get_xrootd_pid():
-    '''Finds the xrootd pid via `service xrootd status`'''
-    _, stdout, _ = xrootd_service_command('status')
-    try:
-        return re.search(r'(?:pid|PID)[:\s\(]*(\d+)', stdout).group(1)
-    except AttributeError:
-        htcondor.log(htcondor.LogLevel.Error, 'ERROR: Could not find XRootD service PID')
-        raise
-
-def xrootd_service_command(cmd):
-    '''Accepts an init command and passes it to the XRootD init script'''
-    service_name = 'xrootd'
-    try:
-        # To support systemd, we need to specify which configuration xrootd should use
-        rc, _, _ = run_command(['systemctl', '--version'])
-        for config in ('cache', 'origin'):
-            if os.path.exists('/etc/xrootd/xrootd-stashcache-%s-server.cfg' % config):
-                service_name = 'xrootd@stashcache-%s-server' % config
-                break
-        if service_name is 'xrootd':
-            htcondor.log(htcondor.LogLevel.Error, 'ERROR: Could not %s XRootD service + ' \
-                         'due to missing cache and origin configurations.' % cmd)
-            sys.exit(1)
-    except OSError, e:
-        # systemctl isn't installed, assume sysvinit
-        if e.errno == errno.ENOENT:
-            pass
+    xrootd_url = 'root://' + hostname
+    while True:
+        logging.debug('Collecting cache stats from %s', cache_path)
+        cache_ad = xrootd_cache_stats.collect_cache_stats(xrootd_url, cache_path)
+        cache_ad['STASHCACHE_DaemonVersion'] = '##VERSION##'
+        if cache_ad['ping_response_status'] == 'ok':
+            logging.debug('XRootD server (%s) status: OK', xrootd_url)
+            pool = central_coll.query(htcondor.AdTypes.Collector)[0]['Machine']
+            logging.info('Advertising StashCache ads to %s', pool)
+            # Save and restore euid, as advertise() changes it
+            old_uid = os.geteuid()
+            central_coll.advertise([cache_ad], 'UPDATE_STARTD_AD')
+            os.seteuid(old_uid)
         else:
-            htcondor.log(htcondor.LogLevel.Error, 'ERROR: Could not determine how to %s the XRootD service' % cmd)
-            raise
+            logging.warning('No heartbeat from XRootD server')
 
-    rc, stdout, stderr = run_command(['service', service_name, cmd])
-    return rc, stdout, stderr
-
-def run_command(command):
-    p = Popen(command, stdout=PIPE, stderr=PIPE)
-    stdout, stderr = p.communicate()
-    return p.returncode, stdout, stderr
+        if one_shot:
+            break
+        else:
+            # ads need to be updated every 15 min
+            logging.debug('Sleeping until next ad refresh')
+            time.sleep(900)
 
 def main():
-    htcondor.enable_log()
+    '''Main function'''
+    args = parse_args()
+
+    # Enable logging
+    log_level = max(3 - args.verbose_count, 0) * 10
+    log_format = '%(levelname)s: %(message)s'
+    logging.basicConfig(level=log_level, format=log_format)
 
     # Check for existence of host cert/key pair
     for pki in 'cert', 'key':
         pki_path = '/etc/grid-security/host%s.pem' % pki
         if not os.path.exists(pki_path):
-            htcondor.log(htcondor.LogLevel.Error, 'ERROR: Could not find host %s at %s' % (pki, pki_path))
+            logging.error('Could not find host %s at %s', pki, pki_path)
             sys.exit(1)
 
-    # Start XRootD and monitor the service
-    start_xrootd()
+    # Monitor the xrootd service
     hostname = socket.getfqdn()
-    heartbeat = HeartBeatThread(hostname, _exception_queue)
-    heartbeat.start()
+    heart_beat(hostname, one_shot=args.one_shot, cache_path=args.cache_path)
 
-    # Accept HTCondor daemon signals
-    for signum in _accepted_signals.iterkeys():
-        signal.signal(signum, manage_xrootd)
-    signal.signal(signal.SIGALRM, raise_heartbeat_exception)
-    while True:
-        signal.pause()
+def parse_args():
+    '''Parse CLI options'''
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('--one-shot', default=False, action='store_true',
+                        help='Run once, rather than persistently')
+    parser.add_argument('--cache-path', default='/stash',
+                        help='Path to the local XRootD stashcache directory')
+    parser.add_argument('-v', '--verbose', dest='verbose_count',
+                        action='count', default=0,
+                        help='Increase log verbosity (repeatable)')
+    return parser.parse_args()
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Remove systemctl from stashcache script and add one-shot mode
- Remove update of local collector
- Allow cache directory to be specified on CLI
- Switch to python logging
- Save and restore euid, as calling Condor's advertise() changes it to the condor user

Add systemd unit to periodically run StashCache stats reporting script
- Add systemd service and timer
- Remove condor service configuration

This closes #7