### PR TITLE
Auto-generate the Authfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,9 +80,9 @@ install:
 	install -p -m 0644 configs/stashcache-cache-server-auth.conf $(DESTDIR)/usr/lib/tmpfiles.d
 	# Authfile updater scripts
 	mkdir -p $(DESTDIR)/usr/libexec/stashcache-cache-server
-	install -p -m 0644 src/authfile-public-update  $(DESTDIR)/usr/libexec/stashcache-cache-server
+	install -p -m 0755 src/authfile-public-update  $(DESTDIR)/usr/libexec/stashcache-cache-server
 	mkdir -p $(DESTDIR)/usr/libexec/stashcache-cache-server-auth
-	install -p -m 0644 src/authfile-update  $(DESTDIR)/usr/libexec/stashcache-cache-server-auth
+	install -p -m 0755 src/authfile-update  $(DESTDIR)/usr/libexec/stashcache-cache-server-auth
 
 $(TARBALL_NAME): $(DIST_FILES)
 	$(eval TEMP_DIR := $(shell mktemp -d -p . $(DIST_DIR_PREFIX)XXXXXXXXXX))

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,11 @@ install:
 	# systemd unit files
 	mkdir -p $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)
 	install -p -m 0644 $(SYSTEMD_UNITS) $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)
+	# systemd unit overrides
+	mkdir -p $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd@stashcache-cache-server.service.d
+	install -p -m 0644 configs/10-stashcache-overrides.conf $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd@stashcache-cache-server.service.d
+	mkdir -p $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd@stashcache-cache-server-auth.service.d
+	install -p -m 0644 configs/10-stashcache-auth-overrides.conf $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd@stashcache-cache-server-auth.service.d
 
 $(TARBALL_NAME): $(DIST_FILES)
 	$(eval TEMP_DIR := $(shell mktemp -d -p . $(DIST_DIR_PREFIX)XXXXXXXXXX))

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ install:
 	mkdir -p $(DESTDIR)/usr/libexec/stashcache-cache-server
 	install -p -m 0755 src/authfile-public-update  $(DESTDIR)/usr/libexec/stashcache-cache-server
 	mkdir -p $(DESTDIR)/usr/libexec/stashcache-cache-server-auth
-	install -p -m 0755 src/authfile-update  $(DESTDIR)/usr/libexec/stashcache-cache-server-auth
+	install -p -m 0755 src/authfile-update src/renew-proxy $(DESTDIR)/usr/libexec/stashcache-cache-server-auth
 
 $(TARBALL_NAME): $(DIST_FILES)
 	$(eval TEMP_DIR := $(shell mktemp -d -p . $(DIST_DIR_PREFIX)XXXXXXXXXX))

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ VERSION := 0.9
 SBIN_FILES := src/stashcache
 INSTALL_SBIN_DIR := usr/sbin
 XROOTD_CONFIG := configs/Authfile-auth configs/Authfile-noauth configs/stashcache-robots.txt configs/xrootd-stashcache-cache-server.cfg configs/xrootd-stashcache-origin-server.cfg
-SYSTEMD_UNITS := configs/xrootd-renew-proxy.service configs/xrootd-renew-proxy.timer configs/stashcache-reporter.service configs/stashcache-reporter.timer
+SYSTEMD_UNITS := configs/xrootd-renew-proxy.service configs/xrootd-renew-proxy.timer configs/stashcache-reporter.service configs/stashcache-reporter.timer configs/stashcache-authfile-public.service configs/stashcache-authfile-public.timer configs/stashcache-authfile.service configs/stashcache-authfile.timer
 INSTALL_XROOTD_DIR := etc/xrootd
 INSTALL_SYSTEMD_UNITDIR := usr/lib/systemd/system
 PYTHON_LIB := src/xrootd_cache_stats.py
@@ -72,6 +72,17 @@ install:
 	install -p -m 0644 configs/10-stashcache-overrides.conf $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd@stashcache-cache-server.service.d
 	mkdir -p $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd@stashcache-cache-server-auth.service.d
 	install -p -m 0644 configs/10-stashcache-auth-overrides.conf $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd@stashcache-cache-server-auth.service.d
+	# systemd tempfiles
+	mkdir -p $(DESTDIR)/run/stashcache-cache-server
+	mkdir -p $(DESTDIR)/run/stashcache-cache-server-auth
+	mkdir -p $(DESTDIR)/usr/lib/tmpfiles.d
+	install -p -m 0644 configs/stashcache-cache-server.conf $(DESTDIR)/usr/lib/tmpfiles.d
+	install -p -m 0644 configs/stashcache-cache-server-auth.conf $(DESTDIR)/usr/lib/tmpfiles.d
+	# Authfile updater scripts
+	mkdir -p $(DESTDIR)/usr/libexec/stashcache-cache-server
+	install -p -m 0644 src/authfile-public-update  $(DESTDIR)/usr/libexec/stashcache-cache-server
+	mkdir -p $(DESTDIR)/usr/libexec/stashcache-cache-server-auth
+	install -p -m 0644 src/authfile-update  $(DESTDIR)/usr/libexec/stashcache-cache-server-auth
 
 $(TARBALL_NAME): $(DIST_FILES)
 	$(eval TEMP_DIR := $(shell mktemp -d -p . $(DIST_DIR_PREFIX)XXXXXXXXXX))

--- a/configs/10-stashcache-auth-overrides.conf
+++ b/configs/10-stashcache-auth-overrides.conf
@@ -1,0 +1,3 @@
+
+[Unit]
+Wants=xrootd-renew-proxy.service xrootd-renew-proxy.timer stashcache-reporter.service stashcache-reporter.timer fetch-crl-boot.service fetch-crl-cron.service

--- a/configs/10-stashcache-auth-overrides.conf
+++ b/configs/10-stashcache-auth-overrides.conf
@@ -1,3 +1,3 @@
 
 [Unit]
-Wants=xrootd-renew-proxy.service xrootd-renew-proxy.timer stashcache-reporter.service stashcache-reporter.timer fetch-crl-boot.service fetch-crl-cron.service
+Wants=xrootd-renew-proxy.service xrootd-renew-proxy.timer stashcache-reporter.service stashcache-reporter.timer fetch-crl-boot.service fetch-crl-cron.service stashcache-authfile.service stashcache-authfile.timer

--- a/configs/10-stashcache-auth-overrides.conf
+++ b/configs/10-stashcache-auth-overrides.conf
@@ -1,4 +1,14 @@
 
 [Unit]
-Wants=xrootd-renew-proxy.service xrootd-renew-proxy.timer stashcache-reporter.service stashcache-reporter.timer fetch-crl-boot.service fetch-crl-cron.service stashcache-authfile.service stashcache-authfile.timer
-After=stashcache-authfile.service
+
+# Service dependencies:
+# - Hard dependency on the proxy generation: wait until done and require it
+#   to succeed.
+# - Make sure the authfile is generated before startup, but make it a softer
+#   dependency: we want to allow Xrootd to restart even if the topology service
+#   is down.
+# - Depends on fetch-crl and the reporter script, but doesn't need these
+#   to finish or succeed for startup.
+Requires=xrootd-renew-proxy.service
+Wants=xrootd-renew-proxy.timer stashcache-reporter.service stashcache-reporter.timer fetch-crl-boot.service fetch-crl-cron.service stashcache-authfile.service stashcache-authfile.timer
+After=stashcache-authfile.service xrootd-renew-proxy.service

--- a/configs/10-stashcache-auth-overrides.conf
+++ b/configs/10-stashcache-auth-overrides.conf
@@ -1,3 +1,4 @@
 
 [Unit]
 Wants=xrootd-renew-proxy.service xrootd-renew-proxy.timer stashcache-reporter.service stashcache-reporter.timer fetch-crl-boot.service fetch-crl-cron.service stashcache-authfile.service stashcache-authfile.timer
+After=stashcache-authfile.service

--- a/configs/10-stashcache-auth-overrides.conf
+++ b/configs/10-stashcache-auth-overrides.conf
@@ -10,5 +10,5 @@
 # - Depends on fetch-crl and the reporter script, but doesn't need these
 #   to finish or succeed for startup.
 Requires=xrootd-renew-proxy.service
-Wants=xrootd-renew-proxy.timer stashcache-reporter.service stashcache-reporter.timer fetch-crl-boot.service fetch-crl-cron.service stashcache-authfile.service stashcache-authfile.timer
+Wants=xrootd-renew-proxy.timer stashcache-reporter.timer fetch-crl-boot.service fetch-crl-cron.service stashcache-authfile.service stashcache-authfile.timer
 After=stashcache-authfile.service xrootd-renew-proxy.service

--- a/configs/10-stashcache-overrides.conf
+++ b/configs/10-stashcache-overrides.conf
@@ -1,3 +1,4 @@
 
 [Unit]
 Wants=stashcache-reporter.service stashcache-reporter.timer stashcache-authfile.service stashcache-authfile.timer
+After=stashcache-authfile.servic

--- a/configs/10-stashcache-overrides.conf
+++ b/configs/10-stashcache-overrides.conf
@@ -1,4 +1,4 @@
 
 [Unit]
-Wants=stashcache-reporter.service stashcache-reporter.timer stashcache-authfile.service stashcache-authfile.timer
-After=stashcache-authfile.servic
+Wants=stashcache-reporter.service stashcache-reporter.timer stashcache-authfile-public.service stashcache-authfile-public.timer
+After=stashcache-authfile-public.service

--- a/configs/10-stashcache-overrides.conf
+++ b/configs/10-stashcache-overrides.conf
@@ -1,0 +1,3 @@
+
+[Unit]
+Wants=stashcache-reporter.service stashcache-reporter.timer

--- a/configs/10-stashcache-overrides.conf
+++ b/configs/10-stashcache-overrides.conf
@@ -1,4 +1,4 @@
 
 [Unit]
-Wants=stashcache-reporter.service stashcache-reporter.timer stashcache-authfile-public.service stashcache-authfile-public.timer
+Wants=stashcache-reporter.timer stashcache-authfile-public.service stashcache-authfile-public.timer
 After=stashcache-authfile-public.service

--- a/configs/10-stashcache-overrides.conf
+++ b/configs/10-stashcache-overrides.conf
@@ -1,3 +1,3 @@
 
 [Unit]
-Wants=stashcache-reporter.service stashcache-reporter.timer
+Wants=stashcache-reporter.service stashcache-reporter.timer stashcache-authfile.service stashcache-authfile.timer

--- a/configs/stashcache-authfile-public.service
+++ b/configs/stashcache-authfile-public.service
@@ -4,7 +4,7 @@ Description=StashCache public Authfile generator
 [Service]
 User=xrootd
 Group=xrootd
-Type=simple
+Type=oneshot
 ExecStart=/usr/libexec/stashcache-cache-server/authfile-public-update
 
 [Install]

--- a/configs/stashcache-authfile-public.service
+++ b/configs/stashcache-authfile-public.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=StashCache public Authfile generator
+
+[Service]
+User=xrootd
+Group=xrootd
+Type=simple
+ExecStart=/usr/libexec/stashcache-cache-server/authfile-public-update
+
+[Install]
+WantedBy=multi-user.target

--- a/configs/stashcache-authfile-public.timer
+++ b/configs/stashcache-authfile-public.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=StashCache Authfile generator
+
+[Timer]
+OnBootSec=15m
+OnUnitActiveSec=15m
+RandomizedDelaySec=3m
+Unit=stashcache-authfile-public.service
+
+[Install]
+WantedBy=timers.target

--- a/configs/stashcache-authfile.service
+++ b/configs/stashcache-authfile.service
@@ -4,7 +4,7 @@ Description=StashCache Authfile generator
 [Service]
 User=xrootd
 Group=xrootd
-Type=simple
+Type=oneshot
 ExecStart=/usr/libexec/stashcache-cache-server-auth/authfile-update
 
 [Install]

--- a/configs/stashcache-authfile.service
+++ b/configs/stashcache-authfile.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=StashCache Authfile generator
+
+[Service]
+User=xrootd
+Group=xrootd
+Type=simple
+ExecStart=/usr/libexec/stashcache-cache-server-auth/authfile-update
+
+[Install]
+WantedBy=multi-user.target

--- a/configs/stashcache-authfile.timer
+++ b/configs/stashcache-authfile.timer
@@ -5,7 +5,7 @@ Description=StashCache Authfile generator
 OnBootSec=15m
 OnUnitActiveSec=15m
 RandomizedDelaySec=3m
-Unit=stashcache-authfile-public.service
+Unit=stashcache-authfile.service
 
 [Install]
 WantedBy=timers.target

--- a/configs/stashcache-authfile.timer
+++ b/configs/stashcache-authfile.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=StashCache Authfile generator
+
+[Timer]
+OnBootSec=15m
+OnUnitActiveSec=15m
+RandomizedDelaySec=3m
+Unit=stashcache-authfile-public.service
+
+[Install]
+WantedBy=timers.target

--- a/configs/stashcache-cache-server-auth.conf
+++ b/configs/stashcache-cache-server-auth.conf
@@ -1,0 +1,2 @@
+# The auto-generated authfile will live here
+d /run/stashcache-cache-server 0775 xrootd xrootd

--- a/configs/stashcache-cache-server.conf
+++ b/configs/stashcache-cache-server.conf
@@ -1,0 +1,2 @@
+# The auto-generated authfile will live here
+d /run/stashcache-cache-server-auth 0775 xrootd xrootd

--- a/configs/stashcache-reporter.service
+++ b/configs/stashcache-reporter.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Report StashCache usage stats
+Wants=fetch-crl-cron.service
 
 [Service]
 User=root

--- a/configs/xrootd-renew-proxy.service
+++ b/configs/xrootd-renew-proxy.service
@@ -1,11 +1,17 @@
 [Unit]
-Description=Renew xrootd proxy
+Description=Generate fresh xrootd proxy
+
+# Have systemd require the existence of these files;
+# if they aren't present, this service will fail with
+# a reasonable error message.
+AssertPathExists=/etc/grid-security/xrd/xrdcert.pem
+AssertPathExists=/etc/grid-security/xrd/xrdkey.pem
 
 [Service]
 User=xrootd
 Group=xrootd
-Type = oneshot
-ExecStart = /bin/grid-proxy-init -cert /etc/grid-security/xrd/xrdcert.pem -key /etc/grid-security/xrd/xrdkey.pem -out /tmp/x509up_xrootd -valid 48:00
+Type=oneshot
+ExecStart = /usr/libexec/stashcache-cache-server-auth/renew-proxy
 
 [Install]
 WantedBy=multi-user.target

--- a/configs/xrootd-stashcache-cache-server.cfg
+++ b/configs/xrootd-stashcache-cache-server.cfg
@@ -38,12 +38,12 @@ if named stashcache-cache-server-auth
      -key:/etc/grid-security/xrd/xrdkey.pem \
      -crl:1 \
      -authzfun:libXrdLcmaps.so \
-     -authzfunparms:--lcmapscfg,/etc/xrootd/lcmaps.cfg,--loglevel,4|useglobals \
-     -gmapopt:10 \
+     -authzfunparms:--no-authz \
+     -gmapopt:0 \
      -authzto:3600
 
    xrd.port 8443
-   acc.authdb /etc/xrootd/Authfile-auth
+   acc.authdb /run/stashcache-cache-server-auth/Authfile
    sec.protbind * gsi
    xrd.protocol http:8443 libXrdHttp.so
    pss.origin xrootd-local.unl.edu:1094
@@ -59,7 +59,7 @@ if named stashcache-cache-server-auth
 else
    # The unauthenticated instance runs on port 1094 (Xrootd) and 8000 (HTTP)
    # It uses a separate auth file from the authenticated instance.
-   acc.authdb /etc/xrootd/Authfile-noauth
+   acc.authdb /run/stashcache-cache-server/Authfile
    sec.protbind * none
    xrd.protocol http:8000 libXrdHttp.so
 fi

--- a/configs/xrootd-stashcache-cache-server.cfg
+++ b/configs/xrootd-stashcache-cache-server.cfg
@@ -49,7 +49,7 @@ if named stashcache-cache-server-auth
    pss.origin xrootd-local.unl.edu:1094
 
    # Proxy cert for retrieving data from origin servers
-   setenv X509_USER_PROXY = /tmp/x509up_xrootd
+   setenv X509_USER_PROXY = /run/stashcache-cache-server-auth/x509_proxy
 
    http.cadir /etc/grid-security/certificates
    http.cert /etc/grid-security/xrd/xrdcert.pem

--- a/configs/xrootd-stashcache-cache-server.cfg
+++ b/configs/xrootd-stashcache-cache-server.cfg
@@ -38,7 +38,7 @@ if named stashcache-cache-server-auth
      -key:/etc/grid-security/xrd/xrdkey.pem \
      -crl:1 \
      -authzfun:libXrdLcmaps.so \
-     -authzfunparms:--no-authz \
+     -authzfunparms:--lcmapscfg,/etc/xrootd/lcmaps.cfg,--no-authz \
      -gmapopt:0 \
      -authzto:3600
 

--- a/rpm/StashCache-Daemon.spec
+++ b/rpm/StashCache-Daemon.spec
@@ -58,6 +58,7 @@ Group: Grid
 Summary: Metapackage for a cache server
 
 Requires: %{name}-daemon
+Requires: curl
 
 %description cache-server
 
@@ -74,8 +75,9 @@ Group: Grid
 Summary: Metapackage for an authenticated cache server
 
 Requires: %{name}-cache-server
-Requires: xrootd-lcmaps >= 1.3.3
+Requires: xrootd-lcmaps >= 1.5.0
 Requires: globus-proxy-utils
+Requires: curl
 
 %description cache-server-auth
 %{summary}
@@ -116,12 +118,23 @@ mkdir -p %{buildroot}%{_sysconfdir}/grid-security/xrd
 %config(noreplace) %{_sysconfdir}/xrootd/stashcache-robots.txt
 %config(noreplace) %{_sysconfdir}/xrootd/xrootd-stashcache-cache-server.cfg
 %config(noreplace) %{_sysconfdir}/xrootd/Authfile-noauth
+%{_unitdir}/stashcache-authfile-public.service
+%{_unitdir}/stashcache-authfile-public.timer
+%{_libexecdir}/%{name}/authfile-public-update
+%{_tmpfilesdir}/%{name}.conf
+%dir /run/%{name}/
 
 %files cache-server-auth
 %config(noreplace) %{_sysconfdir}/xrootd/xrootd-stashcache-cache-server-auth.cfg
 %config(noreplace) %{_sysconfdir}/xrootd/Authfile-auth
 %{_unitdir}/xrootd-renew-proxy.service
 %{_unitdir}/xrootd-renew-proxy.timer
+%{_unitdir}/stashcache-authfile.service
+%{_unitdir}/stashcache-authfile.timer
+%{_libexecdir}/%{name}/authfile-update
+%{_tmpfilesdir}/%{name}.conf
+%dir /run/%{name}/
+
 %attr(-, xrootd, xrootd) %{_sysconfdir}/grid-security/xrd
 
 %changelog

--- a/rpm/StashCache-Daemon.spec
+++ b/rpm/StashCache-Daemon.spec
@@ -122,7 +122,7 @@ mkdir -p %{buildroot}%{_sysconfdir}/grid-security/xrd
 %{_unitdir}/stashcache-authfile-public.timer
 %{_libexecdir}/%{name}-cache-server/authfile-public-update
 %{_tmpfilesdir}/%{name}-cache-server.conf
-%dir /run/%{name}-cache-server/
+%attr(0755, xrootd, xrootd) %dir /run/%{name}-cache-server/
 
 %files cache-server-auth
 %config(noreplace) %{_sysconfdir}/xrootd/xrootd-stashcache-cache-server-auth.cfg
@@ -133,7 +133,7 @@ mkdir -p %{buildroot}%{_sysconfdir}/grid-security/xrd
 %{_unitdir}/stashcache-authfile.timer
 %{_libexecdir}/%{name}-cache-server-auth/authfile-update
 %{_tmpfilesdir}/%{name}-cache-server-auth.conf
-%dir /run/%{name}-cache-server-auth/
+%attr(0755, xrootd, xrootd) %dir /run/%{name}-cache-server-auth/
 
 %attr(-, xrootd, xrootd) %{_sysconfdir}/grid-security/xrd
 

--- a/rpm/StashCache-Daemon.spec
+++ b/rpm/StashCache-Daemon.spec
@@ -120,9 +120,9 @@ mkdir -p %{buildroot}%{_sysconfdir}/grid-security/xrd
 %config(noreplace) %{_sysconfdir}/xrootd/Authfile-noauth
 %{_unitdir}/stashcache-authfile-public.service
 %{_unitdir}/stashcache-authfile-public.timer
-%{_libexecdir}/%{name}/authfile-public-update
-%{_tmpfilesdir}/%{name}.conf
-%dir /run/%{name}/
+%{_libexecdir}/%{name}-cache-server/authfile-public-update
+%{_tmpfilesdir}/%{name}-cache-server.conf
+%dir /run/%{name}-cache-server/
 
 %files cache-server-auth
 %config(noreplace) %{_sysconfdir}/xrootd/xrootd-stashcache-cache-server-auth.cfg
@@ -131,9 +131,9 @@ mkdir -p %{buildroot}%{_sysconfdir}/grid-security/xrd
 %{_unitdir}/xrootd-renew-proxy.timer
 %{_unitdir}/stashcache-authfile.service
 %{_unitdir}/stashcache-authfile.timer
-%{_libexecdir}/%{name}/authfile-update
-%{_tmpfilesdir}/%{name}.conf
-%dir /run/%{name}/
+%{_libexecdir}/%{name}-cache-server-auth/authfile-update
+%{_tmpfilesdir}/%{name}-cache-server-auth.conf
+%dir /run/%{name}-cache-server-auth/
 
 %attr(-, xrootd, xrootd) %{_sysconfdir}/grid-security/xrd
 

--- a/rpm/StashCache-Daemon.spec
+++ b/rpm/StashCache-Daemon.spec
@@ -106,6 +106,8 @@ mkdir -p %{buildroot}%{_sysconfdir}/grid-security/xrd
 %{python_sitelib}/xrootd_cache_stats.py*
 %{_unitdir}/stashcache-reporter.service
 %{_unitdir}/stashcache-reporter.timer
+%{_unitdir}/xrootd@stashcache-cache-server.service.d/10-stashcache-overrides.conf
+%{_unitdir}/xrootd@stashcache-cache-server-auth.service.d/10-stashcache-auth-overrides.conf
 
 %files origin-server
 %config(noreplace) %{_sysconfdir}/xrootd/xrootd-stashcache-origin-server.cfg

--- a/rpm/StashCache-Daemon.spec
+++ b/rpm/StashCache-Daemon.spec
@@ -132,6 +132,7 @@ mkdir -p %{buildroot}%{_sysconfdir}/grid-security/xrd
 %{_unitdir}/stashcache-authfile.service
 %{_unitdir}/stashcache-authfile.timer
 %{_libexecdir}/%{name}-cache-server-auth/authfile-update
+%{_libexecdir}/%{name}-cache-server-auth/renew-proxy
 %{_tmpfilesdir}/%{name}-cache-server-auth.conf
 %attr(0755, xrootd, xrootd) %dir /run/%{name}-cache-server-auth/
 

--- a/src/authfile-public-update
+++ b/src/authfile-public-update
@@ -1,3 +1,3 @@
 #!/bin/sh
-curl https://topology.opensciencegrid.org/stashcache/authfile > /run/stashcache-cache-server/Authfile.tmp
+curl https://topology.opensciencegrid.org/stashcache/authfile-public > /run/stashcache-cache-server/Authfile.tmp
 mv /run/stashcache-cache-server/Authfile.tmp /run/stashcache-cache-server/Authfile

--- a/src/authfile-public-update
+++ b/src/authfile-public-update
@@ -1,3 +1,4 @@
-#!/bin/sh
-curl https://topology.opensciencegrid.org/stashcache/authfile-public > /run/stashcache-cache-server/Authfile.tmp
+#!/bin/bash
+CACHE_FQDN="${CACHE_FQDN:=$(hostname)}"
+curl --silent --show-error --fail "https://topology.opensciencegrid.org/stashcache/authfile-public?cache_fqdn=$CACHE_FQDN" > /run/stashcache-cache-server/Authfile.tmp && \
 mv /run/stashcache-cache-server/Authfile.tmp /run/stashcache-cache-server/Authfile

--- a/src/authfile-public-update
+++ b/src/authfile-public-update
@@ -1,0 +1,3 @@
+#!/bin/sh
+curl https://topology.opensciencegrid.org/stashcache/authfile > /run/stashcache-cache-server/Authfile.tmp
+mv /run/stashcache-cache-server/Authfile.tmp /run/stashcache-cache-server/Authfile

--- a/src/authfile-update
+++ b/src/authfile-update
@@ -1,0 +1,3 @@
+#!/bin/sh
+curl https://topology.opensciencegrid.org/stashcache/authfile > /run/stashcache-cache-server-auth/Authfile.tmp
+mv /run/stashcache-cache-server-auth/Authfile.tmp /run/stashcache-cache-server-auth/Authfile

--- a/src/authfile-update
+++ b/src/authfile-update
@@ -1,3 +1,4 @@
-#!/bin/sh
-curl https://topology.opensciencegrid.org/stashcache/authfile > /run/stashcache-cache-server-auth/Authfile.tmp
+#!/bin/bash
+CACHE_FQDN="${CACHE_FQDN:=$(hostname)}"
+curl --silent --show-error --fail "https://topology.opensciencegrid.org/stashcache/authfile?cache_fqdn=${CACHE_FQDN}" > /run/stashcache-cache-server-auth/Authfile.tmp && \
 mv /run/stashcache-cache-server-auth/Authfile.tmp /run/stashcache-cache-server-auth/Authfile

--- a/src/renew-proxy
+++ b/src/renew-proxy
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+HOSTCERT=/etc/grid-security/xrd/xrdcert.pem
+HOSTKEY=/etc/grid-security/xrd/xrdkey.pem
+PROXYFILE=/run/stashcache-cache-server-auth/x509_proxy
+/bin/grid-proxy-init -cert "$HOSTCERT" \
+                     -key "$HOSTKEY" \
+                     -out "${PROXYFILE}.tmp" \
+                     -valid 48:00 \
+  &&
+mv "${PROXYFILE}.tmp" "${PROXYFILE}"


### PR DESCRIPTION
The Authfile is now generated on the topology application; this is a corresponding daemon-side change to ensure the StashCache server uses the topology-generated file.