### PR TITLE
Add back missing condor-python dep

### DIFF
--- a/rpm/StashCache-Daemon.spec
+++ b/rpm/StashCache-Daemon.spec
@@ -19,6 +19,8 @@ BuildRequires: systemd
 Group: Grid
 Summary: Scripts and configuration for StashCache management
 
+# Necessary for daemon to report back to the OSG Collector.
+Requires: condor-python
 # We utilize a configuration directive (`continue`) introduced in XRootD 4.9.
 Requires: xrootd-server >= 1:4.9.0
 Requires: grid-certificates >= 7


### PR DESCRIPTION
This was incorrectly removed; we no longer need the condor _daemon_, but we still require the condor _client_.