### PR TITLE
Authfile update script tweaks

### DIFF
--- a/src/authfile-public-update
+++ b/src/authfile-public-update
@@ -1,4 +1,4 @@
 #!/bin/bash
-CACHE_FQDN="${CACHE_FQDN:=$(hostname)}"
+CACHE_FQDN=${CACHE_FQDN:-$(hostname -f)}
 curl --silent --show-error --fail "https://topology.opensciencegrid.org/stashcache/authfile-public?cache_fqdn=$CACHE_FQDN" > /run/stashcache-cache-server/Authfile.tmp && \
 mv /run/stashcache-cache-server/Authfile.tmp /run/stashcache-cache-server/Authfile

--- a/src/authfile-update
+++ b/src/authfile-update
@@ -1,4 +1,4 @@
 #!/bin/bash
-CACHE_FQDN="${CACHE_FQDN:=$(hostname)}"
+CACHE_FQDN=${CACHE_FQDN:-$(hostname -f)}
 curl --silent --show-error --fail "https://topology.opensciencegrid.org/stashcache/authfile?cache_fqdn=${CACHE_FQDN}" > /run/stashcache-cache-server-auth/Authfile.tmp && \
 mv /run/stashcache-cache-server-auth/Authfile.tmp /run/stashcache-cache-server-auth/Authfile


### PR DESCRIPTION
- eliminate redundant assignment
- if we want the FQDN we should ask for it