### PR TITLE
Setup origin GSI authentication.

### DIFF
--- a/configs/config.d/50-stash-origin-authz.cfg
+++ b/configs/config.d/50-stash-origin-authz.cfg
@@ -8,7 +8,36 @@
 # This file is part of the StashCache Daemon
 # https://opensciencegrid.github.io/StashCache-Daemon
 
-xrd.allow host *
-sec.protocol  host
-sec.protbind  * none
+# Enable the authorization module, even if we have an unauthenticated instance.
+ofs.authorize 1
+# Log both successes and failures in authorization.
+acc.audit deny grant
 
+
+if named stashcache-origin-server-auth
+
+   xrootd.seclib /usr/lib64/libXrdSec.so
+
+   # Set libXrdLcmaps to be used only to invoke Globus and libvoms
+   # to verify the proxy; authorizations will be handled internally.
+   sec.protocol /usr/lib64 gsi \
+        -certdir:/etc/grid-security/certificates \
+        -cert:/etc/grid-security/xrd/xrdcert.pem \
+        -key:/etc/grid-security/xrd/xrdkey.pem \
+        -crl:1 \
+        -authzfun:libXrdLcmaps.so \
+        -authzfunparms:--lcmapscfg,/etc/xrootd/lcmaps.cfg,--no-authz \
+        -gmapopt:0 \
+        -authzto:3600
+
+   sec.protbind * gsi
+
+   acc.authdb /etc/xrootd/Authfile
+
+else if named stashcache-origin-server
+
+   xrd.allow host *
+   sec.protocol  host
+   sec.protbind  * none
+
+fi

--- a/configs/config.d/50-stash-origin-authz.cfg
+++ b/configs/config.d/50-stash-origin-authz.cfg
@@ -14,7 +14,7 @@ ofs.authorize 1
 acc.audit deny grant
 
 
-if named stashcache-origin-server-auth
+if named stash-origin-auth
 
    xrootd.seclib /usr/lib64/libXrdSec.so
 
@@ -34,7 +34,7 @@ if named stashcache-origin-server-auth
 
    acc.authdb /etc/xrootd/Authfile
 
-else if named stashcache-origin-server
+else if named stash-origin
 
    xrd.allow host *
    sec.protocol  host


### PR DESCRIPTION
Still need to work out a way to generate the `/etc/xrootd/Authfile` appropriately.

The authentication setup is the same approach as for the cache server.